### PR TITLE
Fix bug with sequence not found by including bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested on Windows.
 
 You will need
 - VS Code with **ExtendScript Debugger** extension from Adobe.
-- exiftool - download and put exiftool.exe in some folder accessible with PATH.
+- [exiftool](https://exiftool.org/) - download and put exiftool.exe in some folder accessible with PATH.
 
 ## Usage
 
@@ -25,9 +25,9 @@ You will need
     - Run `apply-warp-effect.jsx`
     - You can customize smoothness and cropLessSmoothMore of Warp Stabilizer effect by modifying the script
     - On each starge, color label of the sequence will be modified for convenience, as process can take long, and can fail in the middle
-- No as the effect applied, we want to export all the sequences
+- Now as the effect applied, we want to export all the sequences
     - Create a preset for export, e.g. "Copy of Match Source - High bitrate - Canon"
-    - The script will only work with custom preset
+    - The script will only work with custom preset, so make sure the path in the script defined in `encoderPresetFile` is correct
     - Select needed sequences
     - Run `export.jsx`
     - You can modify outputDirectory by modifying the script

--- a/apply-warp-effect.jsx
+++ b/apply-warp-effect.jsx
@@ -83,7 +83,7 @@ function projectItemToSequence(projectItem) {
 
 function sequenceToQSequence(sequence) {
     for (var i = 0; i < qe.project.numSequences; i++) {
-        var qsequence = qe.project.getSequenceAt(i);
+        var qsequence = qe.project.getBinAt(0).getSequenceAt(i);
         if (qsequence.guid === sequence.sequenceID) {
             return qsequence;
         }


### PR DESCRIPTION
First of all, thanks a lot for sharing this tool, it was really useful!

When running the `apply-warp-effect` script I got an error because `qe.project.getSequenceAt(i)` is `null`. After debugging, I found out that the sequence is actually inside the bin, and not directly inside the project, so I fixed it by changing the line to `qe.project.getBinAt(0).getSequenceAt(i)`.

I've also added extra information to the `README.md` file.